### PR TITLE
ES 2.3 upgrade : Update fields names for attachments

### DIFF
--- a/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
+++ b/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
@@ -126,7 +126,7 @@ public class AttachmentIndexingServiceConnector  extends ElasticIndexingServiceC
 
     //Construct attachment field
     JSONObject attachmentFields = new JSONObject();
-    attachmentFields.put("file", fastVectorHighlighterField);
+    attachmentFields.put("content", fastVectorHighlighterField);
     attachmentFields.put("title", postingHighlighterField);
     JSONObject attachmentField = new JSONObject();
     attachmentField.put("type", "attachment");

--- a/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -47,7 +47,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
 
   private static final String INDEX = "wiki";
   private static final String TYPE = "wiki,wiki-page,wiki-attachment";
-  private static final String[] SEARCH_FIELDS = {"name", "title", "content", "comment", "file"};
+  private static final String[] SEARCH_FIELDS = {"name", "title", "content", "comment", "file.content"};
 
   public WikiElasticSearchServiceConnector(InitParams initParams, ElasticSearchingClient client) {
     super(initParams, client);

--- a/dao-services/src/main/resources/conf/portal/configuration.xml
+++ b/dao-services/src/main/resources/conf/portal/configuration.xml
@@ -101,7 +101,7 @@
           <property name="type" value="wiki,wiki-page,wiki-attachment"/>
           <property name="enable" value="${exo.unified-search.connector.wiki.enable:true}"/>
           <property name="titleField" value="title"/>
-          <property name="searchFields" value="name,title,content,comment,file"/>
+          <property name="searchFields" value="name,title,content,comment,file.content"/>
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
This PR upgrades from ES 1.7 to 2.3. The only changes is about the name of the attachments fields.
