### PR TITLE
WIKI-1257 : remove dependencies to old exo-es-search addon since all search APIs have been integrated in PLF

### DIFF
--- a/dao-services/pom.xml
+++ b/dao-services/pom.xml
@@ -35,9 +35,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.exoplatform.addons.es</groupId>
-      <artifactId>exo-es-search-service</artifactId>
-      <version>${exo.es.search.version}</version>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-search</artifactId>
+      <version>${org.exoplatform.platform.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/migration-services/pom.xml
+++ b/migration-services/pom.xml
@@ -54,9 +54,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.addons.es</groupId>
-      <artifactId>exo-es-search-service</artifactId>
-      <version>${exo.es.search.version}</version>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-search</artifactId>
+      <version>${org.exoplatform.platform.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
     <!-- Platform Project Dependencies -->
     <org.exoplatform.platform.version>4.4.x-SNAPSHOT</org.exoplatform.platform.version>
     <org.exoplatform.core.version>2.6.4-GA</org.exoplatform.core.version>
-    <exo.es.search.version>1.0.x-SNAPSHOT</exo.es.search.version>
     <hibernate.version>4.2.21.Final</hibernate.version>
     <jackson.version>2.1.3</jackson.version>
     <hsqldb.version>2.3.2</hsqldb.version>


### PR DESCRIPTION
Remove dependencies to old exo-es-search addon since all search APIs have been integrated in PLF
