### PR TITLE
WIKI-1268: Re-indexation of tribe attachments is failing

### DIFF
--- a/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
+++ b/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
@@ -87,16 +87,10 @@ public class AttachmentIndexingServiceConnector  extends ElasticIndexingServiceC
     Map<String,String> fields = new HashMap<>();
     Document doc = new Document(TYPE, id, getUrl(attachment), fileItem.getFileInfo().getUpdatedDate(),
         computePermissions(fileItem.getFileInfo().getUpdater(),attachment), fields);
-    int index = fileItem.getFileInfo().getName().lastIndexOf(".");
-    if(index != -1) {
-      doc.addField("title", fileItem.getFileInfo().getName().substring(0, index - 1));
-    }
-    else{
-      doc.addField("title", fileItem.getFileInfo().getName());
-    }
-
+    String fileName = org.exoplatform.wiki.utils.Utils.escapeIllegalCharacterInName(fileItem.getFileInfo().getName());
+    doc.addField("title", fileName);
     doc.addField("file", fileItem.getAsByte());
-    doc.addField("name", fileItem.getFileInfo().getName());
+    doc.addField("name", fileName);
     doc.addField("createdDate", String.valueOf(attachment.getCreatedDate().getTime()));
     doc.addField("updatedDate", String.valueOf(fileItem.getFileInfo().getUpdatedDate().getTime()));
     PageEntity page = attachment.getPage();

--- a/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
+++ b/dao-services/src/main/java/org/exoplatform/wiki/jpa/search/AttachmentIndexingServiceConnector.java
@@ -87,10 +87,9 @@ public class AttachmentIndexingServiceConnector  extends ElasticIndexingServiceC
     Map<String,String> fields = new HashMap<>();
     Document doc = new Document(TYPE, id, getUrl(attachment), fileItem.getFileInfo().getUpdatedDate(),
         computePermissions(fileItem.getFileInfo().getUpdater(),attachment), fields);
-    String fileName = org.exoplatform.wiki.utils.Utils.escapeIllegalCharacterInName(fileItem.getFileInfo().getName());
-    doc.addField("title", fileName);
+    doc.addField("title", attachment.getFullTitle());
     doc.addField("file", fileItem.getAsByte());
-    doc.addField("name", fileName);
+    doc.addField("name", fileItem.getFileInfo().getName());
     doc.addField("createdDate", String.valueOf(attachment.getCreatedDate().getTime()));
     doc.addField("updatedDate", String.valueOf(fileItem.getFileInfo().getUpdatedDate().getTime()));
     PageEntity page = attachment.getPage();


### PR DESCRIPTION
Use the same name escaping as used for new uploaded files (as seen [here)](https://github.com/exoplatform/wiki/blob/develop/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiUploadAttachment.java#L98)

In fact this problem happens only for old uploaded files because there wasn't name escaping before, and so the file name is stored as it is.
